### PR TITLE
Optimize gas usage

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -4,7 +4,6 @@
     "compiler-version": "off",
     "mark-callable-contracts": "off",
     "no-empty-blocks": "off",
-    "reason-string": "off",
     "func-visibility": ["warn", { "ignoreConstructors": true }]
   }
 }

--- a/abi/IRewardEthToken.json
+++ b/abi/IRewardEthToken.json
@@ -184,14 +184,14 @@
     "name": "checkpoints",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint128",
         "name": "",
-        "type": "uint256"
+        "type": "uint128"
       },
       {
-        "internalType": "uint256",
+        "internalType": "uint64",
         "name": "",
-        "type": "uint256"
+        "type": "uint64"
       }
     ],
     "stateMutability": "view",
@@ -284,9 +284,9 @@
     "name": "rewardPerToken",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint64",
         "name": "",
-        "type": "uint256"
+        "type": "uint64"
       }
     ],
     "stateMutability": "view",
@@ -323,9 +323,9 @@
     "name": "totalRewards",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint128",
         "name": "",
-        "type": "uint256"
+        "type": "uint128"
       }
     ],
     "stateMutability": "view",
@@ -411,13 +411,31 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account1",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "account2",
+        "type": "address"
+      }
+    ],
+    "name": "updateRewardCheckpoints",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "updateTimestamp",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint64",
         "name": "",
-        "type": "uint256"
+        "type": "uint64"
       }
     ],
     "stateMutability": "view",

--- a/abi/IRewardEthToken.json
+++ b/abi/IRewardEthToken.json
@@ -189,9 +189,9 @@
         "type": "uint128"
       },
       {
-        "internalType": "uint64",
+        "internalType": "uint128",
         "name": "",
-        "type": "uint64"
+        "type": "uint128"
       }
     ],
     "stateMutability": "view",
@@ -284,9 +284,9 @@
     "name": "rewardPerToken",
     "outputs": [
       {
-        "internalType": "uint64",
+        "internalType": "uint128",
         "name": "",
-        "type": "uint64"
+        "type": "uint128"
       }
     ],
     "stateMutability": "view",

--- a/abi/ISolos.json
+++ b/abi/ISolos.json
@@ -22,7 +22,7 @@
         "type": "bytes32"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "sender",
         "type": "address"
@@ -53,7 +53,7 @@
         "type": "bytes32"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "sender",
         "type": "address"

--- a/abi/OwnablePausableUpgradeable.json
+++ b/abi/OwnablePausableUpgradeable.json
@@ -1,0 +1,386 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PAUSER_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "addAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "addPauser",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRoleMember",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "isAdmin",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "isPauser",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "removeAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "removePauser",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abi/PausableUpgradeable.json
+++ b/abi/PausableUpgradeable.json
@@ -1,0 +1,41 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -26,14 +26,14 @@ contract Validators is IValidators, OwnablePausableUpgradeable {
 
     // @dev Checks whether the caller is the collector contract.
     modifier onlyCollector() {
-        require(msg.sender == solos || msg.sender == pool, "Validators: permission denied");
+        require(msg.sender == solos || msg.sender == pool, "Validators: access denied");
         _;
     }
 
     /**
      * @dev See {IValidators-initialize}.
      */
-    function initialize(address _admin, address _pool, address _solos) public override initializer {
+    function initialize(address _admin, address _pool, address _solos) external override initializer {
         __OwnablePausableUpgradeable_init(_admin);
         pool = _pool;
         solos = _solos;
@@ -42,7 +42,7 @@ contract Validators is IValidators, OwnablePausableUpgradeable {
     /**
      * @dev See {IValidators-isOperator}.
      */
-    function isOperator(address _account) public override view returns (bool) {
+    function isOperator(address _account) external override view returns (bool) {
         return hasRole(OPERATOR_ROLE, _account);
     }
 
@@ -64,7 +64,7 @@ contract Validators is IValidators, OwnablePausableUpgradeable {
      * @dev See {IValidators-register}.
      */
     function register(bytes32 _validatorId) external override onlyCollector whenNotPaused {
-        require(!publicKeys[_validatorId], "Validators: public key has been already used");
+        require(!publicKeys[_validatorId], "Validators: invalid public key");
         publicKeys[_validatorId] = true;
     }
 }

--- a/contracts/collectors/Pool.sol
+++ b/contracts/collectors/Pool.sol
@@ -46,7 +46,7 @@ contract Pool is IPool, OwnablePausableUpgradeable {
         address _validators,
         bytes32 _withdrawalCredentials
     )
-        public override initializer
+        external override initializer
     {
         __OwnablePausableUpgradeable_init(_admin);
         stakedEthToken = IStakedEthToken(_stakedEthToken);
@@ -83,10 +83,10 @@ contract Pool is IPool, OwnablePausableUpgradeable {
      * @dev See {IPool-registerValidator}.
      */
     function registerValidator(Validator calldata _validator) external override whenNotPaused {
-        require(validators.isOperator(msg.sender), "Pool: permission denied");
+        require(validators.isOperator(msg.sender), "Pool: access denied");
 
         // reduce pool collected amount
-        collectedAmount = collectedAmount.sub(VALIDATOR_DEPOSIT, "Pool: insufficient collected amount");
+        collectedAmount = collectedAmount.sub(VALIDATOR_DEPOSIT, "Pool: insufficient amount");
 
         // register validator
         validators.register(keccak256(abi.encodePacked(_validator.publicKey)));

--- a/contracts/collectors/Solos.sol
+++ b/contracts/collectors/Solos.sol
@@ -72,7 +72,7 @@ contract Solos is ISolos, ReentrancyGuard, OwnablePausable {
      * @dev See {ISolos-addDeposit}.
      */
     function addDeposit(bytes32 _withdrawalCredentials) external payable override whenNotPaused {
-        require(_withdrawalCredentials != "" && _withdrawalCredentials[0] == 0x00, "Solos: invalid withdrawal credentials");
+        require(_withdrawalCredentials != "" && _withdrawalCredentials[0] == 0x00, "Solos: invalid credentials");
         require(msg.value > 0 && msg.value.mod(VALIDATOR_DEPOSIT) == 0, "Solos: invalid deposit amount");
 
         bytes32 soloId = keccak256(abi.encodePacked(address(this), msg.sender, _withdrawalCredentials));
@@ -100,7 +100,7 @@ contract Solos is ISolos, ReentrancyGuard, OwnablePausable {
         Solo storage solo = solos[soloId];
 
         // solhint-disable-next-line not-rely-on-time
-        require(block.timestamp >= solo.releaseTime, "Solos: current time is before release time");
+        require(block.timestamp >= solo.releaseTime, "Solos: too early cancel");
 
         uint256 newAmount = solo.amount.sub(_amount, "Solos: insufficient balance");
         require(newAmount.mod(VALIDATOR_DEPOSIT) == 0, "Solos: invalid cancel amount");
@@ -140,7 +140,7 @@ contract Solos is ISolos, ReentrancyGuard, OwnablePausable {
      * @dev See {ISolos-registerValidator}.
      */
     function registerValidator(Validator calldata _validator) external override whenNotPaused {
-        require(validators.isOperator(msg.sender), "Solos: permission denied");
+        require(validators.isOperator(msg.sender), "Solos: access denied");
 
         // update solo balance
         Solo storage solo = solos[_validator.soloId];

--- a/contracts/interfaces/IRewardEthToken.sol
+++ b/contracts/interfaces/IRewardEthToken.sol
@@ -27,7 +27,7 @@ interface IRewardEthToken is IERC20Upgradeable {
     */
     struct Checkpoint {
         uint128 reward;
-        uint64 rewardPerToken;
+        uint128 rewardPerToken;
     }
 
     /**
@@ -97,13 +97,13 @@ interface IRewardEthToken is IERC20Upgradeable {
     /**
     * @dev Function for retrieving current reward per token used for account reward calculation.
     */
-    function rewardPerToken() external view returns (uint64);
+    function rewardPerToken() external view returns (uint128);
 
     /**
     * @dev Function for retrieving account's current checkpoint.
     * @param account - address of the account to retrieve the checkpoint for.
     */
-    function checkpoints(address account) external view returns (uint128, uint64);
+    function checkpoints(address account) external view returns (uint128, uint128);
 
     /**
     * @dev Function for updating account's reward checkpoint.

--- a/contracts/interfaces/IRewardEthToken.sol
+++ b/contracts/interfaces/IRewardEthToken.sol
@@ -26,8 +26,8 @@ interface IRewardEthToken is IERC20Upgradeable {
     * @param reward - user reward checkpoint.
     */
     struct Checkpoint {
-        uint256 rewardPerToken;
-        uint256 reward;
+        uint128 reward;
+        uint64 rewardPerToken;
     }
 
     /**
@@ -85,31 +85,38 @@ interface IRewardEthToken is IERC20Upgradeable {
     function setMaintainerFee(uint256 _newMaintainerFee) external;
 
     /**
-    * @dev Function for retrieving the last total rewards update timestamp.
-    */
-    function updateTimestamp() external view returns (uint256);
-
-    /**
     * @dev Function for retrieving the total rewards amount.
     */
-    function totalRewards() external view returns (uint256);
+    function totalRewards() external view returns (uint128);
+
+    /**
+    * @dev Function for retrieving the last total rewards update timestamp.
+    */
+    function updateTimestamp() external view returns (uint64);
 
     /**
     * @dev Function for retrieving current reward per token used for account reward calculation.
     */
-    function rewardPerToken() external view returns (uint256);
+    function rewardPerToken() external view returns (uint64);
 
     /**
     * @dev Function for retrieving account's current checkpoint.
     * @param account - address of the account to retrieve the checkpoint for.
     */
-    function checkpoints(address account) external view returns (uint256, uint256);
+    function checkpoints(address account) external view returns (uint128, uint64);
 
     /**
     * @dev Function for updating account's reward checkpoint.
     * @param account - address of the account to update the reward checkpoint for.
     */
     function updateRewardCheckpoint(address account) external;
+
+    /**
+    * @dev Function for updating reward checkpoints for two accounts simultaneously (for gas savings).
+    * @param account1 - address of the first account to update the reward checkpoint for.
+    * @param account2 - address of the second account to update the reward checkpoint for.
+    */
+    function updateRewardCheckpoints(address account1, address account2) external;
 
     /**
     * @dev Function for updating validators total rewards.

--- a/contracts/interfaces/ISolos.sol
+++ b/contracts/interfaces/ISolos.sol
@@ -44,7 +44,7 @@ interface ISolos {
     */
     event DepositAdded(
         bytes32 indexed soloId,
-        address sender,
+        address indexed sender,
         uint256 amount,
         bytes32 withdrawalCredentials
     );
@@ -58,7 +58,7 @@ interface ISolos {
     */
     event DepositCanceled(
         bytes32 indexed soloId,
-        address sender,
+        address indexed sender,
         uint256 amount,
         bytes32 withdrawalCredentials
     );

--- a/contracts/libraries/ECDSA.sol
+++ b/contracts/libraries/ECDSA.sol
@@ -61,8 +61,8 @@ library ECDSA {
         // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
         // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
         // these malleable signatures as well.
-        require(uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0, "ECDSA: invalid signature 's' value");
-        require(v == 27 || v == 28, "ECDSA: invalid signature 'v' value");
+        require(uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0, "ECDSA: invalid signature 's'");
+        require(v == 27 || v == 28, "ECDSA: invalid signature 'v'");
 
         // If the signature is valid (and not malleable), return the signer address
         address signer = ecrecover(hash, v, r, s);

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -14,7 +14,7 @@ contract ERC20Mock is ERC20PermitUpgradeable {
     address private owner;
     mapping (address => uint256) private _balances;
 
-    function initialize(address _owner, uint256 initialBalance, string memory name, string memory symbol) public initializer {
+    function initialize(address _owner, uint256 initialBalance, string memory name, string memory symbol) external initializer {
         __ERC20_init(name, symbol);
         __ERC20Permit_init(name);
         owner = _owner;
@@ -30,8 +30,8 @@ contract ERC20Mock is ERC20PermitUpgradeable {
     }
 
     function _transfer(address sender, address recipient, uint256 amount) internal override {
-        require(sender != address(0), "ERC20: transfer from the zero address");
-        require(recipient != address(0), "ERC20: transfer to the zero address");
+        require(sender != address(0), "ERC20: invalid sender");
+        require(recipient != address(0), "ERC20: invalid receiver");
 
         _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
         _balances[recipient] = _balances[recipient].add(amount);

--- a/contracts/mocks/OwnablePausableUpgradeableMock.sol
+++ b/contracts/mocks/OwnablePausableUpgradeableMock.sol
@@ -5,7 +5,7 @@ pragma solidity 0.7.5;
 import "../presets/OwnablePausableUpgradeable.sol";
 
 contract OwnablePausableUpgradeableMock is OwnablePausableUpgradeable {
-    function initialize(address _admin) public initializer {
+    function initialize(address _admin) external initializer {
         __OwnablePausableUpgradeable_init(_admin);
     }
 }

--- a/contracts/presets/OwnablePausable.sol
+++ b/contracts/presets/OwnablePausable.sol
@@ -19,7 +19,7 @@ abstract contract OwnablePausable is IOwnablePausable, Pausable, AccessControl {
     * @dev Modifier for checking whether the caller is an admin.
     */
     modifier onlyAdmin() {
-        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "OwnablePausable: permission denied");
+        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "OwnablePausable: access denied");
         _;
     }
 
@@ -27,7 +27,7 @@ abstract contract OwnablePausable is IOwnablePausable, Pausable, AccessControl {
     * @dev Modifier for checking whether the caller is a pauser.
     */
     modifier onlyPauser() {
-        require(hasRole(PAUSER_ROLE, msg.sender), "OwnablePausable: permission denied");
+        require(hasRole(PAUSER_ROLE, msg.sender), "OwnablePausable: access denied");
         _;
     }
 
@@ -42,7 +42,7 @@ abstract contract OwnablePausable is IOwnablePausable, Pausable, AccessControl {
     /**
      * @dev See {IOwnablePausable-isAdmin}.
      */
-    function isAdmin(address _account) public override view returns (bool) {
+    function isAdmin(address _account) external override view returns (bool) {
         return hasRole(DEFAULT_ADMIN_ROLE, _account);
     }
 
@@ -63,7 +63,7 @@ abstract contract OwnablePausable is IOwnablePausable, Pausable, AccessControl {
     /**
      * @dev See {IOwnablePausable-isPauser}.
      */
-    function isPauser(address _account) public override view returns (bool) {
+    function isPauser(address _account) external override view returns (bool) {
         return hasRole(PAUSER_ROLE, _account);
     }
 

--- a/contracts/presets/OwnablePausableUpgradeable.sol
+++ b/contracts/presets/OwnablePausableUpgradeable.sol
@@ -19,7 +19,7 @@ abstract contract OwnablePausableUpgradeable is IOwnablePausable, PausableUpgrad
     * @dev Modifier for checking whether the caller is an admin.
     */
     modifier onlyAdmin() {
-        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "OwnablePausableUpgradeable: permission denied");
+        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "OwnablePausable: access denied");
         _;
     }
 
@@ -27,7 +27,7 @@ abstract contract OwnablePausableUpgradeable is IOwnablePausable, PausableUpgrad
     * @dev Modifier for checking whether the caller is a pauser.
     */
     modifier onlyPauser() {
-        require(hasRole(PAUSER_ROLE, msg.sender), "OwnablePausableUpgradeable: permission denied");
+        require(hasRole(PAUSER_ROLE, msg.sender), "OwnablePausable: access denied");
         _;
     }
 
@@ -51,7 +51,7 @@ abstract contract OwnablePausableUpgradeable is IOwnablePausable, PausableUpgrad
     /**
      * @dev See {IOwnablePausable-isAdmin}.
      */
-    function isAdmin(address _account) public override view returns (bool) {
+    function isAdmin(address _account) external override view returns (bool) {
         return hasRole(DEFAULT_ADMIN_ROLE, _account);
     }
 
@@ -72,7 +72,7 @@ abstract contract OwnablePausableUpgradeable is IOwnablePausable, PausableUpgrad
     /**
      * @dev See {IOwnablePausable-isPauser}.
      */
-    function isPauser(address _account) public override view returns (bool) {
+    function isPauser(address _account) external override view returns (bool) {
         return hasRole(PAUSER_ROLE, _account);
     }
 

--- a/contracts/tokens/ERC20Upgradeable.sol
+++ b/contracts/tokens/ERC20Upgradeable.sol
@@ -142,7 +142,7 @@ abstract contract ERC20Upgradeable is Initializable, IERC20Upgradeable {
     function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
         _transfer(sender, recipient, amount);
         if (sender != msg.sender && _allowances[sender][msg.sender] != uint256(-1)) {
-            _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount, "ERC20: transfer amount exceeds allowance"));
+            _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount, "ERC20: invalid amount"));
         }
         return true;
     }
@@ -179,7 +179,7 @@ abstract contract ERC20Upgradeable is Initializable, IERC20Upgradeable {
      * `subtractedValue`.
      */
     function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
-        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue, "ERC20: invalid amount"));
         return true;
     }
 
@@ -213,8 +213,8 @@ abstract contract ERC20Upgradeable is Initializable, IERC20Upgradeable {
      * - `spender` cannot be the zero address.
      */
     function _approve(address owner, address spender, uint256 amount) internal virtual {
-        require(owner != address(0), "ERC20: approve from the zero address");
-        require(spender != address(0), "ERC20: approve to the zero address");
+        require(owner != address(0), "ERC20: invalid owner");
+        require(spender != address(0), "ERC20: invalid spender");
 
         _allowances[owner][spender] = amount;
         emit Approval(owner, spender, amount);

--- a/contracts/tokens/RewardEthToken.sol
+++ b/contracts/tokens/RewardEthToken.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.7.5;
 
 import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/SafeCastUpgradeable.sol";
 import "../presets/OwnablePausableUpgradeable.sol";
 import "../interfaces/IStakedEthToken.sol";
 import "../interfaces/IRewardEthToken.sol";
@@ -15,21 +16,22 @@ import "./ERC20PermitUpgradeable.sol";
  */
 contract RewardEthToken is IRewardEthToken, OwnablePausableUpgradeable, ERC20PermitUpgradeable {
     using SafeMathUpgradeable for uint256;
-
-    // @dev Last rewards update timestamp by balance reporters.
-    uint256 public override updateTimestamp;
-
-    // @dev Total amount of rewards.
-    uint256 public override totalRewards;
+    using SafeCastUpgradeable for uint256;
 
     // @dev Maps account address to its reward checkpoint.
     mapping(address => Checkpoint) public override checkpoints;
 
-    // @dev Reward per token for user reward calculation.
-    uint256 public override rewardPerToken;
-
     // @dev Maintainer percentage fee.
     uint256 public override maintainerFee;
+
+    // @dev Total amount of rewards.
+    uint128 public override totalRewards;
+
+    // @dev Last rewards update timestamp by balance reporters.
+    uint64 public override updateTimestamp;
+
+    // @dev Reward per token for user reward calculation.
+    uint64 public override rewardPerToken;
 
     // @dev Address of the maintainer, where the fee will be paid.
     address public override maintainer;
@@ -54,7 +56,7 @@ contract RewardEthToken is IRewardEthToken, OwnablePausableUpgradeable, ERC20Per
         address _maintainer,
         uint256 _maintainerFee
     )
-        public override initializer
+        external override initializer
     {
         __OwnablePausableUpgradeable_init(_admin);
         __ERC20_init("StakeWise Reward ETH", "rwETH");
@@ -84,7 +86,7 @@ contract RewardEthToken is IRewardEthToken, OwnablePausableUpgradeable, ERC20Per
      * @dev See {IRewardEthToken-setMaintainerFee}.
      */
     function setMaintainerFee(uint256 _newMaintainerFee) external override onlyAdmin {
-        require(_newMaintainerFee < 10000, "RewardEthToken: invalid new maintainer fee");
+        require(_newMaintainerFee < 10000, "RewardEthToken: invalid fee");
         maintainerFee = _newMaintainerFee;
         emit MaintainerFeeUpdated(_newMaintainerFee);
     }
@@ -102,7 +104,7 @@ contract RewardEthToken is IRewardEthToken, OwnablePausableUpgradeable, ERC20Per
     function balanceOf(address account) public view override returns (uint256) {
         Checkpoint memory cp = checkpoints[account];
 
-        uint256 periodRewardPerToken = rewardPerToken.sub(cp.rewardPerToken);
+        uint256 periodRewardPerToken = uint256(rewardPerToken).sub(cp.rewardPerToken);
         if (periodRewardPerToken == 0) {
             // no new rewards
             return cp.reward;
@@ -115,18 +117,28 @@ contract RewardEthToken is IRewardEthToken, OwnablePausableUpgradeable, ERC20Per
         }
 
         // return checkpoint reward + current reward
-        return cp.reward.add(deposit.mul(periodRewardPerToken).div(1e18));
+        return uint256(cp.reward).add(deposit.mul(periodRewardPerToken).div(1e18));
     }
 
     /**
      * @dev See {ERC20-_transfer}.
      */
     function _transfer(address sender, address recipient, uint256 amount) internal override whenNotPaused {
-        require(sender != address(0), "RewardEthToken: transfer from the zero address");
-        require(recipient != address(0), "RewardEthToken: transfer to the zero address");
+        require(sender != address(0), "RewardEthToken: invalid sender");
+        require(recipient != address(0), "RewardEthToken: invalid receiver");
 
-        checkpoints[sender] = Checkpoint(rewardPerToken, balanceOf(sender).sub(amount, "RewardEthToken: invalid amount"));
-        checkpoints[recipient] = Checkpoint(rewardPerToken, balanceOf(recipient).add(amount));
+        uint64 _rewardPerToken = rewardPerToken;
+        Checkpoint memory senderCheckpoint = Checkpoint(
+            balanceOf(sender).sub(amount, "RewardEthToken: invalid amount").toUint128(),
+            _rewardPerToken
+        );
+        Checkpoint memory recipientCheckpoint = Checkpoint(
+            balanceOf(recipient).add(amount).toUint128(),
+            _rewardPerToken
+        );
+
+        checkpoints[sender] = senderCheckpoint;
+        checkpoints[recipient] = recipientCheckpoint;
 
         emit Transfer(sender, recipient, amount);
     }
@@ -135,14 +147,27 @@ contract RewardEthToken is IRewardEthToken, OwnablePausableUpgradeable, ERC20Per
      * @dev See {IRewardEthToken-updateRewardCheckpoint}.
      */
     function updateRewardCheckpoint(address account) external override {
-        checkpoints[account] = Checkpoint(rewardPerToken, balanceOf(account));
+        Checkpoint memory checkpoint = Checkpoint(balanceOf(account).toUint128(), rewardPerToken);
+        checkpoints[account] = checkpoint;
+    }
+
+    /**
+     * @dev See {IRewardEthToken-updateRewardCheckpoints}.
+     */
+    function updateRewardCheckpoints(address account1, address account2) external override {
+        uint64 _rewardPerToken = rewardPerToken;
+        Checkpoint memory checkpoint1 = Checkpoint(balanceOf(account1).toUint128(), _rewardPerToken);
+        Checkpoint memory checkpoint2 = Checkpoint(balanceOf(account2).toUint128(), _rewardPerToken);
+
+        checkpoints[account1] = checkpoint1;
+        checkpoints[account2] = checkpoint2;
     }
 
     /**
      * @dev See {IRewardEthToken-updateTotalRewards}.
      */
     function updateTotalRewards(uint256 newTotalRewards) external override {
-        require(msg.sender == balanceReporters, "RewardEthToken: permission denied");
+        require(msg.sender == balanceReporters, "RewardEthToken: access denied");
 
         uint256 periodRewards = newTotalRewards.sub(totalRewards, "RewardEthToken: invalid new total rewards");
         if (periodRewards == 0) {
@@ -152,26 +177,28 @@ contract RewardEthToken is IRewardEthToken, OwnablePausableUpgradeable, ERC20Per
 
         // calculate reward per token used for account reward calculation
         uint256 maintainerReward = periodRewards.mul(maintainerFee).div(10000);
-        rewardPerToken = rewardPerToken.add(periodRewards.sub(maintainerReward).mul(1e18).div(stakedEthToken.totalDeposits()));
+        uint256 newRewardPerToken = uint256(rewardPerToken).add(periodRewards.sub(maintainerReward).mul(1e18).div(stakedEthToken.totalDeposits()));
 
         // update maintainer's reward
-        checkpoints[maintainer] = Checkpoint(
-            rewardPerToken,
-            balanceOf(maintainer).add(maintainerReward)
+        Checkpoint memory checkpoint = Checkpoint(
+            balanceOf(maintainer).add(maintainerReward).toUint128(),
+            newRewardPerToken.toUint64()
         );
+        checkpoints[maintainer] = checkpoint;
 
+        totalRewards = newTotalRewards.toUint128();
         // solhint-disable-next-line not-rely-on-time
-        updateTimestamp = block.timestamp;
-        totalRewards = newTotalRewards;
+        updateTimestamp = block.timestamp.toUint64();
+        rewardPerToken = newRewardPerToken.toUint64();
 
-        emit RewardsUpdated(periodRewards, newTotalRewards, rewardPerToken, updateTimestamp);
+        emit RewardsUpdated(periodRewards, newTotalRewards, newRewardPerToken, updateTimestamp);
     }
 
     /**
      * @dev See {IRewardEthToken-claimRewards}.
      */
     function claimRewards(address tokenContract, uint256 claimedRewards) external override {
-        require(msg.sender == stakedTokens, "RewardEthToken: permission denied");
+        require(msg.sender == stakedTokens, "RewardEthToken: access denied");
         _transfer(tokenContract, stakedTokens, claimedRewards);
     }
 }

--- a/contracts/tokens/StakedEthToken.sol
+++ b/contracts/tokens/StakedEthToken.sol
@@ -31,7 +31,7 @@ contract StakedEthToken is IStakedEthToken, OwnablePausableUpgradeable, ERC20Per
     /**
      * @dev See {StakedEthToken-initialize}.
      */
-    function initialize(address _admin, address _rewardEthToken, address _pool) public override initializer {
+    function initialize(address _admin, address _rewardEthToken, address _pool) external override initializer {
         __OwnablePausableUpgradeable_init(_admin);
         __ERC20_init("StakeWise Staked ETH", "stETH");
         __ERC20Permit_init("StakeWise Staked ETH");
@@ -57,15 +57,12 @@ contract StakedEthToken is IStakedEthToken, OwnablePausableUpgradeable, ERC20Per
      * @dev See {ERC20-_transfer}.
      */
     function _transfer(address sender, address recipient, uint256 amount) internal override whenNotPaused {
-        require(sender != address(0), "StakedEthToken: transfer from the zero address");
-        require(recipient != address(0), "StakedEthToken: transfer to the zero address");
+        require(sender != address(0), "StakedEthToken: invalid sender");
+        require(recipient != address(0), "StakedEthToken: invalid receiver");
 
-        // start calculating sender rewards with updated deposit amount
-        rewardEthToken.updateRewardCheckpoint(sender);
+        // start calculating sender and recipient rewards with updated deposit amounts
+        rewardEthToken.updateRewardCheckpoints(sender, recipient);
         deposits[sender] = deposits[sender].sub(amount, "StakedEthToken: invalid amount");
-
-        // start calculating recipient rewards with updated deposit amount
-        rewardEthToken.updateRewardCheckpoint(recipient);
         deposits[recipient] = deposits[recipient].add(amount);
 
         emit Transfer(sender, recipient, amount);
@@ -75,7 +72,7 @@ contract StakedEthToken is IStakedEthToken, OwnablePausableUpgradeable, ERC20Per
      * @dev See {IStakedEthToken-mint}.
      */
     function mint(address account, uint256 amount) external override {
-        require(msg.sender == pool, "StakedEthToken: permission denied");
+        require(msg.sender == pool, "StakedEthToken: access denied");
 
         // start calculating account rewards with updated deposit amount
         rewardEthToken.updateRewardCheckpoint(account);

--- a/contracts/tokens/StakedTokens.sol
+++ b/contracts/tokens/StakedTokens.sol
@@ -53,7 +53,7 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
         token.enabled = _isEnabled;
 
         // update token's reward
-        updateTokenRewards(_token);
+        _updateTokenRewards(_token);
 
         emit TokenToggled(_token, _isEnabled);
     }
@@ -84,7 +84,7 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
 
     function _stakeTokens(address _token, uint256 _amount) private {
         // update token's reward
-        updateTokenRewards(_token);
+        _updateTokenRewards(_token);
 
         // withdraw account's current rewards and update balance
         uint256 accountBalance = balances[_token][msg.sender];
@@ -102,7 +102,7 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
      */
     function withdrawTokens(address _token, uint256 _amount) external override nonReentrant whenNotPaused {
         // update token's reward
-        updateTokenRewards(_token);
+        _updateTokenRewards(_token);
 
         // withdraw account's current rewards
         uint256 accountBalance = balances[_token][msg.sender];
@@ -120,7 +120,7 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
      */
     function withdrawRewards(address _token) external override nonReentrant whenNotPaused {
         // update token's reward
-        updateTokenRewards(_token);
+        _updateTokenRewards(_token);
 
         // withdraw account's current rewards
         uint256 accountBalance = balances[_token][msg.sender];
@@ -169,7 +169,7 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
     * @dev Function to update accumulated rewards for token.
     * @param _token - address of the token to update rewards for.
     */
-    function updateTokenRewards(address _token) private {
+    function _updateTokenRewards(address _token) private {
         Token storage token = tokens[_token];
         uint256 claimedRewards = IRewardEthToken(rewardEthToken).balanceOf(_token);
         if (token.totalSupply == 0 || claimedRewards == 0) {
@@ -192,7 +192,7 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
     */
     function _withdrawRewards(address _token, address _account, uint256 _prevBalance, uint256 _newBalance) private {
         Token storage token = tokens[_token];
-        require(_newBalance >= _prevBalance || token.enabled, "StakedTokens: unsupported token");
+        require(_prevBalance >= _newBalance || token.enabled, "StakedTokens: unsupported token");
 
         uint256 accountRewardRate = rewardRates[_token][_account];
         if (token.rewardRate == accountRewardRate) {

--- a/contracts/tokens/StakedTokens.sol
+++ b/contracts/tokens/StakedTokens.sol
@@ -36,7 +36,7 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
     /**
      * @dev See {IStakedTokens-initialize}.
      */
-    function initialize(address _admin, address _rewardEthToken) public override initializer {
+    function initialize(address _admin, address _rewardEthToken) external override initializer {
         __OwnablePausableUpgradeable_init(_admin);
         __ReentrancyGuard_init_unchained();
         rewardEthToken = _rewardEthToken;
@@ -46,7 +46,7 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
      * @dev See {IStakedTokens-toggleTokenContract}.
      */
     function toggleTokenContract(address _token, bool _isEnabled) external override onlyAdmin {
-        require(_token != address(0), "StakedTokens: invalid token address");
+        require(_token != address(0), "StakedTokens: invalid token");
 
         // support token
         Token storage token = tokens[_token];
@@ -83,18 +83,12 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
     }
 
     function _stakeTokens(address _token, uint256 _amount) private {
-        Token storage token = tokens[_token];
-        require(token.enabled, "StakedTokens: token is not supported");
-
         // update token's reward
         updateTokenRewards(_token);
 
-        // withdraw account's current rewards
-        _withdrawRewards(_token, msg.sender);
-
-        // update account's balance
-        token.totalSupply = token.totalSupply.add(_amount);
-        balances[_token][msg.sender] = balances[_token][msg.sender].add(_amount);
+        // withdraw account's current rewards and update balance
+        uint256 accountBalance = balances[_token][msg.sender];
+        _withdrawRewards(_token, msg.sender, accountBalance, accountBalance.add(_amount));
 
         // emit event
         emit TokensStaked(_token, msg.sender, _amount);
@@ -111,12 +105,8 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
         updateTokenRewards(_token);
 
         // withdraw account's current rewards
-        _withdrawRewards(_token, msg.sender);
-
-        // update account's balance
-        Token storage token = tokens[_token];
-        token.totalSupply = token.totalSupply.sub(_amount, "StakedTokens: invalid tokens amount");
-        balances[_token][msg.sender] = balances[_token][msg.sender].sub(_amount, "StakedTokens: invalid tokens amount");
+        uint256 accountBalance = balances[_token][msg.sender];
+        _withdrawRewards(_token, msg.sender, accountBalance, accountBalance.sub(_amount, "StakedTokens: invalid amount"));
 
         // emit event
         emit TokensWithdrawn(_token, msg.sender, _amount);
@@ -133,7 +123,8 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
         updateTokenRewards(_token);
 
         // withdraw account's current rewards
-        _withdrawRewards(_token, msg.sender);
+        uint256 accountBalance = balances[_token][msg.sender];
+        _withdrawRewards(_token, msg.sender, accountBalance, accountBalance);
     }
 
     /**
@@ -199,29 +190,50 @@ contract StakedTokens is IStakedTokens, OwnablePausableUpgradeable, ReentrancyGu
     * @param _token - address of the staked tokens contract.
     * @param _account - account to update.
     */
-    function _withdrawRewards(address _token, address _account) private {
+    function _withdrawRewards(address _token, address _account, uint256 _prevBalance, uint256 _newBalance) private {
         Token storage token = tokens[_token];
         uint256 accountRewardRate = rewardRates[_token][_account];
         if (token.rewardRate == accountRewardRate) {
-            // nothing to withdraw
+            // reward rate has not changed -> update only balance
+            if (_newBalance == _prevBalance) {
+                return;
+            } else if (_newBalance > _prevBalance) {
+                require(token.enabled, "StakedTokens: unsupported token");
+            }
+
+            balances[_token][_account] = _newBalance;
+            token.totalSupply = token.totalSupply.add(_newBalance).sub(_prevBalance);
             return;
         }
 
         // update account reward rate
         rewardRates[_token][_account] = token.rewardRate;
 
-        uint256 accountBalance = balances[_token][_account];
-        if (accountBalance == 0) {
-            // no staked tokens
+        if (_prevBalance == 0) {
+            // no previously staked tokens -> update only balance
+            if (_newBalance == 0) {
+                return;
+            }
+
+            require(token.enabled, "StakedTokens: unsupported token");
+            balances[_token][_account] = _newBalance;
+            token.totalSupply = token.totalSupply.add(_newBalance);
             return;
         }
 
         // calculate period reward
-        uint256 periodReward = accountBalance.mul(token.rewardRate.sub(accountRewardRate)).div(1e18);
+        uint256 periodReward = _prevBalance.mul(token.rewardRate.sub(accountRewardRate)).div(1e18);
 
         // withdraw rewards
         token.totalRewards = token.totalRewards.sub(periodReward);
         emit RewardWithdrawn(_token, _account, periodReward);
+
+        if (_newBalance > _prevBalance) {
+            require(token.enabled, "StakedTokens: unsupported token");
+        }
+
+        balances[_token][_account] = _newBalance;
+        token.totalSupply = token.totalSupply.add(_newBalance).sub(_prevBalance);
 
         IERC20(rewardEthToken).safeTransfer(_account, periodReward);
     }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -136,6 +136,7 @@ module.exports = {
     showTimeSpent: true,
     currency: 'USD',
     maxMethodDiff: 25, // CI will fail if gas usage is > than this %
+    excludeContracts: ['mocks/'],
   },
   abiExporter: {
     path: './abi',

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -142,6 +142,8 @@ module.exports = {
     path: './abi',
     only: [
       'AccessControl',
+      'OwnablePausableUpgradeable',
+      'PausableUpgradeable',
       'IBalanceReporters',
       'IDepositContract',
       'IERC20',

--- a/test/BalanceReporters.test.js
+++ b/test/BalanceReporters.test.js
@@ -155,7 +155,7 @@ contract('BalanceReporters', ([_, ...accounts]) => {
     it('anyone cannot set rwETH uniswap pairs', async () => {
       await expectRevert(
         balanceReporters.setRewardEthUniswapPairs(pairs, { from: anyone }),
-        'OwnablePausableUpgradeable: permission denied'
+        'OwnablePausable: access denied'
       );
       expect(await balanceReporters.getRewardEthUniswapPairs()).to.have.members(
         []
@@ -195,7 +195,7 @@ contract('BalanceReporters', ([_, ...accounts]) => {
         balanceReporters.voteForTotalRewards(ether('1'), {
           from: anyone,
         }),
-        'BalanceReporters: permission denied'
+        'BalanceReporters: access denied'
       );
       expect(await rewardEthToken.totalRewards()).to.bignumber.equal(new BN(0));
     });
@@ -211,7 +211,7 @@ contract('BalanceReporters', ([_, ...accounts]) => {
         balanceReporters.voteForTotalRewards(ether('1'), {
           from: reporter1,
         }),
-        'BalanceReporters: rwETH total rewards vote was already submitted'
+        'BalanceReporters: already voted'
       );
       expect(await rewardEthToken.totalRewards()).to.bignumber.equal(new BN(0));
     });

--- a/test/Validators.test.js
+++ b/test/Validators.test.js
@@ -38,7 +38,7 @@ contract(
         validators.register(validatorId, {
           from: anyone,
         }),
-        'Validators: permission denied'
+        'Validators: access denied'
       );
 
       await validators.register(validatorId, {

--- a/test/pool/registerValidator.test.js
+++ b/test/pool/registerValidator.test.js
@@ -63,7 +63,7 @@ contract('Pool (register validator)', ([_, ...accounts]) => {
       pool.registerValidator(validator, {
         from: other,
       }),
-      'Pool: permission denied'
+      'Pool: access denied'
     );
     await checkCollectorBalance(pool, validatorDeposit);
     await checkPoolCollectedAmount(pool, validatorDeposit);
@@ -88,7 +88,7 @@ contract('Pool (register validator)', ([_, ...accounts]) => {
       pool.setWithdrawalCredentials(withdrawalCredentials, {
         from: other,
       }),
-      'OwnablePausableUpgradeable: permission denied'
+      'OwnablePausable: access denied'
     );
     await checkCollectorBalance(pool, validatorDeposit);
     await checkPoolCollectedAmount(pool, validatorDeposit);
@@ -127,7 +127,7 @@ contract('Pool (register validator)', ([_, ...accounts]) => {
       pool.registerValidator(validator, {
         from: operator,
       }),
-      'Validators: public key has been already used'
+      'Validators: invalid public key'
     );
     await checkCollectorBalance(pool, validatorDeposit);
     await checkPoolCollectedAmount(pool, validatorDeposit);
@@ -147,7 +147,7 @@ contract('Pool (register validator)', ([_, ...accounts]) => {
       pool.registerValidator(validatorParams[1], {
         from: operator,
       }),
-      'Pool: insufficient collected amount'
+      'Pool: insufficient amount'
     );
 
     await checkCollectorBalance(pool, new BN(0));

--- a/test/presets/OwnablePausable.test.js
+++ b/test/presets/OwnablePausable.test.js
@@ -13,6 +13,5 @@ contract('OwnablePausable', ([_, ...accounts]) => {
   ownablePausableTests({
     accounts,
     getOwnableContract,
-    contractName: 'OwnablePausable',
   });
 });

--- a/test/presets/OwnablePausableTests.js
+++ b/test/presets/OwnablePausableTests.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
 
-function ownablePausableTests({ getOwnableContract, accounts, contractName }) {
+function ownablePausableTests({ getOwnableContract, accounts }) {
   let ownableContract;
   let [admin, otherAdmin, pauser, otherPauser, anyone] = accounts;
 
@@ -164,7 +164,7 @@ function ownablePausableTests({ getOwnableContract, accounts, contractName }) {
     it('others cannot pause contract', async () => {
       await expectRevert(
         ownableContract.pause({ from: anyone }),
-        `${contractName}: access denied`
+        'OwnablePausable: access denied'
       );
       expect(await ownableContract.paused()).equal(false);
     });
@@ -173,7 +173,7 @@ function ownablePausableTests({ getOwnableContract, accounts, contractName }) {
       await ownableContract.pause({ from: pauser });
       await expectRevert(
         ownableContract.unpause({ from: anyone }),
-        `${contractName}: access denied`
+        'OwnablePausable: access denied'
       );
       expect(await ownableContract.paused()).equal(true);
     });

--- a/test/presets/OwnablePausableTests.js
+++ b/test/presets/OwnablePausableTests.js
@@ -164,7 +164,7 @@ function ownablePausableTests({ getOwnableContract, accounts, contractName }) {
     it('others cannot pause contract', async () => {
       await expectRevert(
         ownableContract.pause({ from: anyone }),
-        `${contractName}: permission denied`
+        `${contractName}: access denied`
       );
       expect(await ownableContract.paused()).equal(false);
     });
@@ -173,7 +173,7 @@ function ownablePausableTests({ getOwnableContract, accounts, contractName }) {
       await ownableContract.pause({ from: pauser });
       await expectRevert(
         ownableContract.unpause({ from: anyone }),
-        `${contractName}: permission denied`
+        `${contractName}: access denied`
       );
       expect(await ownableContract.paused()).equal(true);
     });

--- a/test/presets/OwnablePausableUpgradeable.test.js
+++ b/test/presets/OwnablePausableUpgradeable.test.js
@@ -18,6 +18,5 @@ contract('OwnablePausableUpgradeable', ([_, ...accounts]) => {
   ownablePausableTests({
     accounts,
     getOwnableContract,
-    contractName: 'OwnablePausableUpgradeable',
   });
 });

--- a/test/solos/addDeposit.test.js
+++ b/test/solos/addDeposit.test.js
@@ -31,7 +31,7 @@ contract('Solos (add deposit)', ([_, ...accounts]) => {
         from: sender1,
         value: validatorDeposit,
       }),
-      'Solos: invalid withdrawal credentials'
+      'Solos: invalid credentials'
     );
     await checkCollectorBalance(solos);
   });
@@ -45,7 +45,7 @@ contract('Solos (add deposit)', ([_, ...accounts]) => {
           value: validatorDeposit,
         }
       ),
-      'Solos: invalid withdrawal credentials'
+      'Solos: invalid credentials'
     );
     await checkCollectorBalance(solos);
   });

--- a/test/solos/cancelDeposit.test.js
+++ b/test/solos/cancelDeposit.test.js
@@ -113,7 +113,7 @@ contract('Solos (cancel deposit)', ([_, ...accounts]) => {
       solos.cancelDeposit(withdrawalCredentials, validatorDeposit, {
         from: sender,
       }),
-      'Solos: current time is before release time'
+      'Solos: too early cancel'
     );
     await checkSolo({
       solos,
@@ -129,7 +129,7 @@ contract('Solos (cancel deposit)', ([_, ...accounts]) => {
       solos.setCancelLockDuration(cancelLockDuration, {
         from: anyone,
       }),
-      'OwnablePausable: permission denied'
+      'OwnablePausable: access denied'
     );
     await checkSolo({
       solos,

--- a/test/solos/registerValidator.test.js
+++ b/test/solos/registerValidator.test.js
@@ -114,7 +114,7 @@ contract('Solos (register validator)', ([_, ...accounts]) => {
           from: operator,
         }
       ),
-      'Validators: public key has been already used'
+      'Validators: invalid public key'
     );
     await checkCollectorBalance(solos, validatorDeposit);
   });
@@ -161,7 +161,7 @@ contract('Solos (register validator)', ([_, ...accounts]) => {
       solos.setValidatorPrice(validatorPrice, {
         from: other,
       }),
-      'OwnablePausable: permission denied'
+      'OwnablePausable: access denied'
     );
   });
 

--- a/test/solos/registerValidator.test.js
+++ b/test/solos/registerValidator.test.js
@@ -83,7 +83,7 @@ contract('Solos (register validator)', ([_, ...accounts]) => {
           from: other,
         }
       ),
-      'Solos: permission denied'
+      'Solos: access denied'
     );
     await checkSolo({
       solos,

--- a/test/tokens/RewardEthToken.test.js
+++ b/test/tokens/RewardEthToken.test.js
@@ -44,7 +44,7 @@ contract('RewardEthToken', ([_, ...accounts]) => {
         rewardEthToken.setMaintainer(otherAccounts[0], {
           from: otherAccounts[0],
         }),
-        'OwnablePausableUpgradeable: permission denied'
+        'OwnablePausable: access denied'
       );
     });
 
@@ -63,7 +63,7 @@ contract('RewardEthToken', ([_, ...accounts]) => {
         rewardEthToken.setMaintainerFee(9999, {
           from: otherAccounts[0],
         }),
-        'OwnablePausableUpgradeable: permission denied'
+        'OwnablePausable: access denied'
       );
     });
 
@@ -82,7 +82,7 @@ contract('RewardEthToken', ([_, ...accounts]) => {
         rewardEthToken.setMaintainerFee(10000, {
           from: admin,
         }),
-        'RewardEthToken: invalid new maintainer fee'
+        'RewardEthToken: invalid fee'
       );
     });
   });
@@ -93,7 +93,7 @@ contract('RewardEthToken', ([_, ...accounts]) => {
         rewardEthToken.updateTotalRewards(ether('10'), {
           from: otherAccounts[0],
         }),
-        'RewardEthToken: permission denied'
+        'RewardEthToken: access denied'
       );
       await checkRewardEthToken({
         rewardEthToken,
@@ -447,7 +447,7 @@ contract('RewardEthToken', ([_, ...accounts]) => {
         rewardEthToken.transfer(constants.ZERO_ADDRESS, value1, {
           from: sender1,
         }),
-        'RewardEthToken: transfer to the zero address'
+        'RewardEthToken: invalid receiver'
       );
 
       await checkRewardEthToken({
@@ -464,7 +464,7 @@ contract('RewardEthToken', ([_, ...accounts]) => {
         rewardEthToken.transferFrom(constants.ZERO_ADDRESS, sender2, value1, {
           from: sender1,
         }),
-        'RewardEthToken: transfer from the zero address'
+        'RewardEthToken: invalid sender'
       );
 
       await checkRewardEthToken({

--- a/test/tokens/StakedEthToken.test.js
+++ b/test/tokens/StakedEthToken.test.js
@@ -53,7 +53,7 @@ contract('StakedEthToken', ([_, ...accounts]) => {
         stakedEthToken.mint(sender1, ether('10'), {
           from: sender1,
         }),
-        'StakedEthToken: permission denied'
+        'StakedEthToken: access denied'
       );
       await checkStakedEthToken({
         stakedEthToken,
@@ -99,7 +99,7 @@ contract('StakedEthToken', ([_, ...accounts]) => {
         stakedEthToken.transfer(constants.ZERO_ADDRESS, value, {
           from: sender1,
         }),
-        'StakedEthToken: transfer to the zero address'
+        'StakedEthToken: invalid receiver'
       );
 
       await checkStakedEthToken({
@@ -116,7 +116,7 @@ contract('StakedEthToken', ([_, ...accounts]) => {
         stakedEthToken.transferFrom(constants.ZERO_ADDRESS, sender2, value, {
           from: sender1,
         }),
-        'StakedEthToken: transfer from the zero address'
+        'StakedEthToken: invalid sender'
       );
 
       await checkStakedEthToken({

--- a/test/tokens/StakedTokensActions.test.js
+++ b/test/tokens/StakedTokensActions.test.js
@@ -116,7 +116,7 @@ contract('StakedTokens Actions', ([_, ...accounts]) => {
         stakedTokens.toggleTokenContract(token.address, true, {
           from: otherAccount,
         }),
-        'OwnablePausableUpgradeable: permission denied'
+        'OwnablePausable: access denied'
       );
     });
 
@@ -125,7 +125,7 @@ contract('StakedTokens Actions', ([_, ...accounts]) => {
         stakedTokens.toggleTokenContract(constants.ZERO_ADDRESS, true, {
           from: admin,
         }),
-        'StakedTokens: invalid token address'
+        'StakedTokens: invalid token'
       );
     });
 
@@ -155,7 +155,7 @@ contract('StakedTokens Actions', ([_, ...accounts]) => {
         stakedTokens.toggleTokenContract(token.address, false, {
           from: otherAccount,
         }),
-        'OwnablePausableUpgradeable: permission denied'
+        'OwnablePausable: access denied'
       );
     });
 
@@ -205,7 +205,7 @@ contract('StakedTokens Actions', ([_, ...accounts]) => {
         stakedTokens.stakeTokens(rewardEthToken.address, stakedBalance, {
           from: tokenHolder1,
         }),
-        'StakedTokens: token is not supported'
+        'StakedTokens: unsupported token'
       );
     });
 
@@ -218,7 +218,7 @@ contract('StakedTokens Actions', ([_, ...accounts]) => {
         stakedTokens.stakeTokens(token.address, stakedBalance, {
           from: tokenHolder1,
         }),
-        'StakedTokens: token is not supported'
+        'StakedTokens: unsupported token'
       );
     });
 
@@ -403,7 +403,7 @@ contract('StakedTokens Actions', ([_, ...accounts]) => {
         stakedTokens.withdrawTokens(otherAccount, stakedBalance, {
           from: tokenHolder1,
         }),
-        'StakedTokens: invalid tokens amount'
+        'StakedTokens: invalid amount'
       );
     });
 
@@ -412,7 +412,7 @@ contract('StakedTokens Actions', ([_, ...accounts]) => {
         stakedTokens.withdrawTokens(token.address, stakedBalance, {
           from: otherAccount,
         }),
-        'StakedTokens: invalid tokens amount'
+        'StakedTokens: invalid amount'
       );
     });
 


### PR DESCRIPTION
# Gas Optimization

## Pool
- `addDeposit`: before=79329, after=78793
- `registerValidator`: before=121630, after=121621

## Solos
- `addDeposit`: before=84634, after=83952
- `cancelDeposit`: before=31859, after=31859
- `registerValidator`: before=114272, after=118361

## StakedEthToken
- `mint`: before=80219, after=79683
- `transfer`: before=57269, after=51537

## RewardEthToken
- `updateTotalRewards`: before=148830, after=105485
- `transfer`: before=121619, after=72949

## StakedTokens
- `stakeTokens`: before=82059, after=79603
- `stakeTokensWithPermit`: before=142239, after=141702
- `toggleTokenContract`: before=52786, after=52045
- `withdrawRewards`: before=108455, after=98350
- `withdrawTokens`: before=97965, after=90639

## BalanceReporters
- `voteForTotalRewards`: before=89151, after=81876