### PR TITLE
Update Oracles.sol: Optimized gas

### DIFF
--- a/contracts/Oracles.sol
+++ b/contracts/Oracles.sol
@@ -24,7 +24,7 @@ contract Oracles is IOracles, OwnablePausableUpgradeable {
     using SafeMathUpgradeable for uint256;
     using CountersUpgradeable for CountersUpgradeable.Counter;
 
-    bytes32 public constant ORACLE_ROLE = keccak256("ORACLE_ROLE");
+    bytes32 public immutable ORACLE_ROLE = keccak256("ORACLE_ROLE");
 
     // @dev Rewards nonce is used to protect from submitting the same rewards vote several times.
     CountersUpgradeable.Counter private rewardsNonce;
@@ -48,8 +48,15 @@ contract Oracles is IOracles, OwnablePausableUpgradeable {
     * @dev Modifier for checking whether the caller is an oracle.
     */
     modifier onlyOracle() {
-        require(hasRole(ORACLE_ROLE, msg.sender), "Oracles: access denied");
+        _checkOracle
         _;
+    }
+
+    /**
+    * @dev Internal function used by the modifier 'onlyOracle'
+    */
+    function _checkOracle() internal view {
+        require(hasRole(ORACLE_ROLE, msg.sender), "Oracles: access denied");
     }
 
     /**
@@ -127,12 +134,12 @@ contract Oracles is IOracles, OwnablePausableUpgradeable {
 
         // check signatures and calculate number of submitted oracle votes
         address[] memory signedOracles = new address[](signatures.length);
-        for (uint256 i = 0; i < signatures.length; i++) {
+        for (uint256 i; i < signatures.length; ++i) {
             bytes memory signature = signatures[i];
             address signer = ECDSAUpgradeable.recover(candidateId, signature);
             require(hasRole(ORACLE_ROLE, signer), "Oracles: invalid signer");
 
-            for (uint256 j = 0; j < i; j++) {
+            for (uint256 j; j < i; ++j) {
                 require(signedOracles[j] != signer, "Oracles: repeated signature");
             }
             signedOracles[i] = signer;
@@ -172,12 +179,12 @@ contract Oracles is IOracles, OwnablePausableUpgradeable {
 
         // check signatures and calculate number of submitted oracle votes
         address[] memory signedOracles = new address[](signatures.length);
-        for (uint256 i = 0; i < signatures.length; i++) {
+        for (uint256 i; i < signatures.length; ++i) {
             bytes memory signature = signatures[i];
             address signer = ECDSAUpgradeable.recover(candidateId, signature);
             require(hasRole(ORACLE_ROLE, signer), "Oracles: invalid signer");
 
-            for (uint256 j = 0; j < i; j++) {
+            for (uint256 j; j < i; ++j) {
                 require(signedOracles[j] != signer, "Oracles: repeated signature");
             }
             signedOracles[i] = signer;
@@ -216,12 +223,12 @@ contract Oracles is IOracles, OwnablePausableUpgradeable {
 
         // check signatures are correct
         address[] memory signedOracles = new address[](signatures.length);
-        for (uint256 i = 0; i < signatures.length; i++) {
+        for (uint256 i; i < signatures.length; ++i) {
             bytes memory signature = signatures[i];
             address signer = ECDSAUpgradeable.recover(candidateId, signature);
             require(hasRole(ORACLE_ROLE, signer), "Oracles: invalid signer");
 
-            for (uint256 j = 0; j < i; j++) {
+            for (uint256 j; j < i; ++j) {
                 require(signedOracles[j] != signer, "Oracles: repeated signature");
             }
             signedOracles[i] = signer;
@@ -231,7 +238,7 @@ contract Oracles is IOracles, OwnablePausableUpgradeable {
         require(merkleProofs.length == depositDataLength, "Oracles: invalid merkle proofs length");
 
         // submit deposit data
-        for (uint256 i = 0; i < depositDataLength; i++) {
+        for (uint256 i; i < depositDataLength; ++i) {
             // register validator
             poolValidators.registerValidator(depositData[i], merkleProofs[i]);
         }


### PR DESCRIPTION
Aims for three main changes that saves gas for this smart contract:

1. Using `immutable` for keccak variables rather than `constant`: This [comment](https://github.com/ethereum/solidity/issues/9232#issuecomment-646131646) by one of Openzeppelin's contributors going to be useful here.
2. Using internal functions for the modifiers which appears more than often: Some Modifiers do appear more than 2-3 times and this kind of increases the gas costs on deploy time..Thus internal functions do help. Again, this [convo](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3347/) between two contributors of Openzeppelin is worthwhile here.
3. Enhancing 'for' loops: These for loops have been improved by changing `++i` to `i++`. Although, I really doubt that this change really gonna make any change in the gas costs..Cuz as per my past experiences, this 'for' loop change works better with solidity version 0.8. Will be worth it if there's might be an updation of solidity version in future. Still refer [this](https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#for-loops-improvement)

Thanks @tsudmi 